### PR TITLE
Обновление зависимостей

### DIFF
--- a/bot/config_reader.py
+++ b/bot/config_reader.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from pydantic import BaseSettings, SecretStr
-
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     bot_token: SecretStr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiogram==3.0.0b7
+aiogram==3.21.0
 python-dotenv==1.0.0
-pydantic==1.10.5
+pydantic==2.11.7
 fluent.runtime==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram==3.21.0
 python-dotenv==1.0.0
 pydantic==2.11.7
 fluent.runtime==0.3.1
+pydantic-settings==2.10.1


### PR DESCRIPTION
Привет! Заметил, что в Python 3.13 (в venv) возникает невозможность установить aiohttp из-за неподдерживаемости pydantic-ом 1.10.5 интерпретатора питона 3.13  версии. Обновил aiogram и pydantic до последних версий, а так же вынес BaseSettings в новый пакет pydantic_settings.

(проверил - и заработало)

На всякий случай заранее прошу прощения за некоторые возможные ошибки из-за моей неопытности